### PR TITLE
Add Timer (Cleaned up for PR)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,15 @@ else ()
     MESSAGE("Not constraining ellipsoid orientation")
 endif ()
 
+# Need to do clean build if change between on and off
+option(RUN_TIMERS "Add in the timers to profile annotated code" ON)
+if (RUN_TIMERS)
+    MESSAGE("Adding timers")
+    add_definitions(-DRUN_TIMERS)
+else ()
+    MESSAGE("Not adding timers")
+endif ()
+
 INCLUDE($ENV{ROS_ROOT}/core/rosbuild/rosbuild.cmake)
 ROSBUILD_INIT()
 SET(ROS_BUILD_STATIC_LIBS true)

--- a/convenience_scripts/podman/high_res_ut_vslam_sequence_executor.sh
+++ b/convenience_scripts/podman/high_res_ut_vslam_sequence_executor.sh
@@ -16,16 +16,16 @@ orb_post_process_base_directory=${root_data_dir}orb_post_process/
 results_root_directory=${root_data_dir}ut_vslam_results/
 lego_loam_out_root_dir=${root_data_dir}lego_loam_out/
 
-sequence_file_base_name="high_res_20230218_1a_7326"
+sequence_file_base_name="20230511183554"
 
-cd $YOLO_DIR
-(python3 detect_ros.py --weights $yolo_weight --img 960 --conf 0.01) &
-yolo_pid=$!
-sleep 5
+# cd $YOLO_DIR
+# (python3 detect_ros.py --weights $yolo_weight --img 960 --conf 0.01) &
+# yolo_pid=$!
+# sleep 5
 
 cd $SLAM_DIR
 
-config_file_base_name="8"
+config_file_base_name="timing"
 python3 src/evaluation/ltm_trajectory_sequence_executor.py \
     --config_file_directory ${config_file_directory} \
     --orb_slam_out_directory ${orb_slam_out_directory} \
@@ -36,7 +36,6 @@ python3 src/evaluation/ltm_trajectory_sequence_executor.py \
     --results_root_directory ${results_root_directory} \
     --config_file_base_name ${config_file_base_name} \
     --sequence_file_base_name ${sequence_file_base_name} \
-    --lego_loam_out_root_dir ${lego_loam_out_root_dir} \
     --output_bb_assoc --record_viz_rosbag --log_to_file
 
 kill -9 $yolo_pid

--- a/include/analysis/cumulative_timer_constants.h
+++ b/include/analysis/cumulative_timer_constants.h
@@ -11,6 +11,147 @@ namespace vslam_types_refactor {
 const std::string kTimerNameVisFunction = "visualization_top_level";
 const std::string kTimerNameVisualFrontendFunction =
     "visual_frontend_top_level";
+const std::string kTimerNameResidualCreator = "residual_creator_top";
+const std::string kTimerNameBbContextRetriever = "bb_context_retriever";
+const std::string kTimerNameBbQuerier = "bb_querier";
+const std::string kTimerNameFrameDataAdderTopLevel =
+    "frame_data_adder_top_level";
+const std::string kTimerNameOptimizationIteration = "optimization_iteration";
+const std::string kTimerNameGlobalBundleAdjustment = "global_bundle_adjustment";
+const std::string kTimerNameLocalBundleAdjustment = "local_bundle_adjustment";
+const std::string kTimerNameConsecutivePosesStable = "consecutive_pose_stable";
+const std::string kTimerNamePhaseOneLbaOpt = "phase_one_lba_opt";
+const std::string kTimerNamePhaseTwoLbaOpt = "phase_two_lba_opt";
+const std::string kTimerNamePostOptResidualCompute =
+    "post_opt_residual_compute";
+const std::string kTimerNameTwoPhaseOptOutlierIdentification =
+    "two_phase_opt_outlier_identification";
+
+// Bounding box front-end
+const std::string kTimerNameBbFrontEndAddBbObs = "bb_front_end_add_bb_obs";
+const std::string kTimerNameBbFrontEndMergePending =
+    "bb_front_end_merge_pending";
+const std::string kTimerNameBbFrontEndAddObservationForObj =
+    "bb_front_end_add_observation_for_obj";
+const std::string kTimerNameAbsBbFrontEndGetBbAssignments =
+    "abs_bb_front_end_get_bb_assignments";
+const std::string kTimerNameBbFrontEndHelpersIdentifyMergeCandidates =
+    "bb_front_end_helpers_identify_merge_candidates";
+const std::string kTimerNameBbFrontEndHelpersGreedilyAssign =
+    "bb_front_end_helpers_greedily_assign";
+const std::string kTimerNameBbFrontEndHelpersRemoveStale =
+    "bb_front_end_helpers_remove_stale";
+const std::string kTimerNameBbFrontEndHelpersGenSingleViewEst =
+    "bb_front_end_helpers_gen_single_view_est";
+const std::string kTimerNameFeatBasedBbFrontEndFilterBbs =
+    "feat_based_bb_front_end_filter_bbs";
+const std::string kTimerNameFeatBasedBbFrontEndGenSingleBbContextInfo =
+    "feat_based_bb_front_end_gen_single_bb_context_info";
+const std::string kTimerNameFeatBasedBbFrontEndCreateObjInfoFromSingle =
+    "feat_based_bb_front_end_create_obj_info_from_single";
+const std::string kTimerNameFeatBasedBbFrontEndMergeObjAssocInfo =
+    "feat_based_bb_front_end_merge_obj_assoc_info";
+const std::string kTimerNameFeatBasedBbFrontEndMergeSingleBbContext =
+    "feat_based_bb_front_end_merge_single_bb_context";
+const std::string kTimerNameFeatBasedBbFrontEndIdentifyCandidateMatches =
+    "feat_based_bb_front_end_identify_candidate_matches";
+const std::string kTimerNameFeatBasedBbFrontEndPruneCandidateMatches =
+    "feat_based_bb_front_end_prune_candidate_matches";
+const std::string kTimerNameFeatBasedBbFrontEndScoreCandidateMatch =
+    "feat_based_bb_front_end_score_candidate_match";
+const std::string kTimerNameFeatBasedBbFrontEndCleanUpBbAssocRound =
+    "feat_based_bb_front_end_clean_up_bb_assoc_round";
+const std::string kTimerNameFeatBasedBbFrontEndSetupInitialEstimateGeneration =
+    "feat_based_bb_front_end_setup_initial_estimate_generation";
+const std::string kTimerNameFeatBasedBbFrontEndTryInitializeEllipsoid =
+    "feat_based_bb_front_end_try_initialize_ellipsoid";
+const std::string kTimerNameFeatBasedBbFrontEndMergeExistingPendingObjects =
+    "feat_based_bb_front_end_merge_existing_pending_objects";
+const std::string kTimerNameFeatBasedBbFrontEndSearchForObjectMerges =
+    "feat_based_bb_front_end_search_for_object_merges";
+const std::string kTimerNameFeatBasedBbFrontEndGetMaxFeatureIntersection =
+    "feat_based_bb_front_end_get_max_feature_intersection";
+
+// Factors
+const std::string kTimerNameFactorShapePriorDouble =
+    "factor_shape_prior_double";
+const std::string kTimerNameFactorShapePriorJacobian =
+    "factor_shape_prior_jacobian";
+const std::string kTimerNameFactorReprojectionCostFunctorDouble =
+    "factor_reprojection_cost_functor_double";
+const std::string kTimerNameFactorReprojectionCostFunctorJacobian =
+    "factor_reprojection_cost_functor_jacobian";
+const std::string kTimerNameFactorBoundingBoxDouble =
+    "factor_bounding_box_double";
+const std::string kTimerNameFactorBoundingBoxJacobian =
+    "factor_bounding_box_jacobian";
+const std::string kTimerNameFactorIndependentObjectMapDouble =
+    "factor_independent_object_map_double";
+const std::string kTimerNameFactorIndependentObjectMapJacobian =
+    "factor_independent_object_map_jacobian";
+const std::string kTimerNameFactorRelativePoseDouble =
+    "factor_relative_pose_double";
+const std::string kTimerNameFactorRelativePoseJacobian =
+    "factor_relative_pose_jacobian";
+const std::string kTimerNameFactorParamPriorDouble =
+    "factor_param_prior_double";
+const std::string kTimerNameFactorParamPriorJacobian =
+    "factor_param_prior_jacobian";
+
+// Pose graph frame data adder
+const std::string kTimerNamePgFrameDataAdderAddFrameDataAssociatedBoundingBox =
+    "pg_frame_data_adder_add_frame_data_associated_bounding_box";
+const std::string kTimerNamePgFrameDataAdderAddVisualFeatureFactors =
+    "pg_frame_data_adder_add_visual_feature_factors";
+const std::string kTimerNamePgFrameDataAdderAddConsecutiveRelativePoseFactors =
+    "pg_frame_data_adder_add_visual_feature_factors";
+
+// Residual creator
+const std::string kTimerNameResidualCreatorObject = "residual_creator_object";
+const std::string kTimerNameResidualCreatorShapeDim =
+    "residual_creator_shape_dim";
+const std::string kTimerNameResidualCreatorReprojection =
+    "residual_creator_reprojection";
+const std::string kTimerNameResidualCreatorRelPose =
+    "residual_creator_rel_pose";
+const std::string kTimerNameResidualLongTermMap =
+    "residual_creator_long_term_map";
+
+// Optimizer
+const std::string kTimerNameOptimizerBuildPgo = "optimizer_build_pgo";
+const std::string kTimerNameOptimizerSolveOptimization = "optimizer_solve_opt";
+const std::string kTimerNameOptimizerApplyMinObsReq = "optimizer_min_obs";
+const std::string kTimerNameOptimizerExtractObservationFactors =
+    "optimizer_extract_observation_factors";
+const std::string kTimerNameOptimizerSetVariability =
+    "optimizer_set_variability";
+const std::string kTimerNameOptimizerRemoveParamWithIdentifiers =
+    "optimizer_remove_param_with_identifiers";
+const std::string kTimerNameOptimizerAddParamBlocksWithIdentifiers =
+    "optimizer_add_param_blocks_with_identifiers";
+const std::string kTimerNameOptimizerAddOrRefreshResidualBlocks =
+    "optimizer_add_or_refresh_residual_blocks";
+const std::string kTimerNameOptimizerRemoveUnnecessaryResidualBlocks =
+    "optimizer_remove_unnecessary_residual_blocks";
+
+// Pose graph
+const std::string kTimerNamePoseGraphGetObjectsWithSemanticClass =
+    "pose_graph_get_objects_with_semantic_class";
+const std::string kTimerNamePoseGraphGetObservationFactorsForObj =
+    "pose_graph_get_observation_factors_for_obj";
+
+// Math utils
+const std::string kTimerNameMathUtilGetPose2Rel1 = "math_util_get_pose_2_rel_1";
+const std::string kTimerNameMathUtilCombinePoses = "math_util_combine_poses";
+const std::string kTimerNameMathUtilGetWorldFramePos =
+    "math_util_get_world_frame_pos";
+const std::string kTimerNameMathUtilGetProjectedPixelCoord =
+    "math_util_get_projected_pixel_coord";
+
+const std::string kTimerNameMathUtilGetCornerLocationsVector =
+    "math_util_get_corner_locations_vector";
+const std::string kTimerNameMathUtilGetProjectedPixelLocation =
+    "math_util_get_projected_pixel_location";
 }  // namespace vslam_types_refactor
 
 #endif  // UT_VSLAM_CUMULATIVE_TIMER_CONSTANTS_H

--- a/include/refactoring/bounding_box_frontend/bounding_box_front_end.h
+++ b/include/refactoring/bounding_box_frontend/bounding_box_front_end.h
@@ -5,6 +5,8 @@
 #ifndef UT_VSLAM_BOUNDING_BOX_FRONT_END_H
 #define UT_VSLAM_BOUNDING_BOX_FRONT_END_H
 
+#include <analysis/cumulative_timer_constants.h>
+#include <analysis/cumulative_timer_factory.h>
 #include <refactoring/optimization/object_pose_graph.h>
 #include <refactoring/types/vslam_obj_opt_types_refactor.h>
 
@@ -78,6 +80,12 @@ class AbstractBoundingBoxFrontEnd {
       const vslam_types_refactor::CameraId &camera_id,
       const std::vector<RawBoundingBox> &bounding_boxes,
       const RawBoundingBoxContextInfo &bb_context) {
+#ifdef RUN_TIMERS
+    CumulativeFunctionTimer::Invocation invoc(
+        CumulativeTimerFactory::getInstance()
+            .getOrCreateFunctionTimer(kTimerNameBbFrontEndAddBbObs)
+            .get());
+#endif
     CHECK(initialized_)
         << "Bounding box front end not initialized properly. Make "
            "sure to call initializeWithLongTermMapFrontEndData "

--- a/include/refactoring/offline/offline_problem_runner.h
+++ b/include/refactoring/offline/offline_problem_runner.h
@@ -5,6 +5,8 @@
 #ifndef UT_VSLAM_OFFLINE_PROBLEM_RUNNER_H
 #define UT_VSLAM_OFFLINE_PROBLEM_RUNNER_H
 
+#include <analysis/cumulative_timer_constants.h>
+#include <analysis/cumulative_timer_factory.h>
 #include <ceres/problem.h>
 #include <refactoring/offline/limit_trajectory_evaluation_params.h>
 #include <refactoring/optimization/object_pose_graph.h>
@@ -154,6 +156,12 @@ class OfflineProblemRunner {
 
     for (FrameId next_frame_id = 1; next_frame_id <= max_frame_id;
          next_frame_id++) {
+#ifdef RUN_TIMERS
+      CumulativeFunctionTimer::Invocation invoc(
+          CumulativeTimerFactory::getInstance()
+              .getOrCreateFunctionTimer(kTimerNameOptimizationIteration)
+              .get());
+#endif
       if (!continue_opt_checker_) {
         LOG(WARNING)
             << "Halted optimization due to continue checker reporting false";
@@ -361,6 +369,12 @@ class OfflineProblemRunner {
         }
       }
       if (run_pgo) {
+#ifdef RUN_TIMERS
+        CumulativeFunctionTimer::Invocation gba_invoc(
+            CumulativeTimerFactory::getInstance()
+                .getOrCreateFunctionTimer(kTimerNameGlobalBundleAdjustment)
+                .get());
+#endif
         // TODO Need to run 1 iteration of tracking first
         LOG(INFO) << "Running tracking before PGO";
         pose_graph_optimizer::OptimizationScopeParams tracking_params =
@@ -405,6 +419,12 @@ class OfflineProblemRunner {
     }
 
     if (run_visual_feature_opt) {
+#ifdef RUN_TIMERS
+      CumulativeFunctionTimer::Invocation invoc_lba(
+          CumulativeTimerFactory::getInstance()
+              .getOrCreateFunctionTimer(kTimerNameLocalBundleAdjustment)
+              .get());
+#endif
       bool visual_feature_opt_enable_two_phase =
           solver_params.feature_outlier_percentage_ > 0;
       // Phase I
@@ -425,6 +445,12 @@ class OfflineProblemRunner {
       std::vector<ceres::ResidualBlockId> residual_block_ids;
       std::vector<double> residuals;
       if (visual_feature_opt_enable_two_phase) {
+#ifdef RUN_TIMERS
+        CumulativeFunctionTimer::Invocation phase_one_invoc(
+            CumulativeTimerFactory::getInstance()
+                .getOrCreateFunctionTimer(kTimerNamePhaseOneLbaOpt)
+                .get());
+#endif
         phase1_optim_success = optimizer_.solveOptimization(&problem,
                                                             solver_params,
                                                             ceres_callbacks,
@@ -432,6 +458,12 @@ class OfflineProblemRunner {
                                                             &residual_block_ids,
                                                             &residuals);
       } else {
+#ifdef RUN_TIMERS
+        CumulativeFunctionTimer::Invocation phase_one_invoc(
+            CumulativeTimerFactory::getInstance()
+                .getOrCreateFunctionTimer(kTimerNamePhaseOneLbaOpt)
+                .get());
+#endif
         phase1_optim_success = optimizer_.solveOptimization(&problem,
                                                             solver_params,
                                                             ceres_callbacks,
@@ -455,6 +487,12 @@ class OfflineProblemRunner {
                          std::unordered_map<ceres::ResidualBlockId, double>>
           factor_types_and_residual_info;
       if (visual_feature_opt_enable_two_phase) {
+#ifdef RUN_TIMERS
+        CumulativeFunctionTimer::Invocation post_opt_residual_invoc(
+            CumulativeTimerFactory::getInstance()
+                .getOrCreateFunctionTimer(kTimerNamePostOptResidualCompute)
+                .get());
+#endif
         size_t residual_idx = 0;
         for (size_t block_idx = 0; block_idx < residual_block_ids.size();
              ++block_idx) {
@@ -521,6 +559,13 @@ class OfflineProblemRunner {
       util::BoostHashSet<std::pair<FactorType, FeatureFactorId>>
           excluded_feature_factor_types_and_ids;
       if (visual_feature_opt_enable_two_phase) {
+#ifdef RUN_TIMERS
+        CumulativeFunctionTimer::Invocation two_phase_opt_outlier_invoc(
+            CumulativeTimerFactory::getInstance()
+                .getOrCreateFunctionTimer(
+                    kTimerNameTwoPhaseOptOutlierIdentification)
+                .get());
+#endif
         std::unordered_map<
             FactorType,
             std::map<double, ceres::ResidualBlockId, std::greater<double>>>
@@ -558,6 +603,12 @@ class OfflineProblemRunner {
       // Phase II
       if (visual_feature_opt_enable_two_phase) {
         // revert back to the old pose graph for Phase II optim
+#ifdef RUN_TIMERS
+        CumulativeFunctionTimer::Invocation phase_two_invoc(
+            CumulativeTimerFactory::getInstance()
+                .getOrCreateFunctionTimer(kTimerNamePhaseTwoLbaOpt)
+                .get());
+#endif
         if (opt_logger.has_value()) {
           opt_logger->setOptimizationTypeParams(
               next_frame_id, start_opt_with_frame == 0, false, true);

--- a/include/refactoring/optimization/object_pose_graph_optimizer.h
+++ b/include/refactoring/optimization/object_pose_graph_optimizer.h
@@ -5,6 +5,8 @@
 #ifndef UT_VSLAM_POSE_GRAPH_OPTIMIZER_H
 #define UT_VSLAM_POSE_GRAPH_OPTIMIZER_H
 
+#include <analysis/cumulative_timer_constants.h>
+#include <analysis/cumulative_timer_factory.h>
 #include <base_lib/basic_utils.h>
 #include <ceres/ceres.h>
 #include <debugging/optimization_logger.h>
@@ -131,6 +133,13 @@ class ObjectPoseGraphOptimizer {
       const util::BoostHashSet<std::pair<vslam_types_refactor::FactorType,
                                          vslam_types_refactor::FeatureFactorId>>
           &excluded_feature_factor_types_and_ids = {}) {
+#ifdef RUN_TIMERS
+    CumulativeFunctionTimer::Invocation invoc(
+        vslam_types_refactor::CumulativeTimerFactory::getInstance()
+            .getOrCreateFunctionTimer(
+                vslam_types_refactor::kTimerNameOptimizerBuildPgo)
+            .get());
+#endif
     // Check for invalid combinations of scope and reject
     CHECK(checkInvalidOptimizationScopeParams(optimization_scope));
 
@@ -630,6 +639,13 @@ class ObjectPoseGraphOptimizer {
       // This is a hack for Ceres < 2+
       std::vector<ceres::ResidualBlockId> *residual_block_id_ptrs = nullptr,
       std::vector<double> *residual_ptrs = nullptr) {
+#ifdef RUN_TIMERS
+    CumulativeFunctionTimer::Invocation invoc(
+        vslam_types_refactor::CumulativeTimerFactory::getInstance()
+            .getOrCreateFunctionTimer(
+                vslam_types_refactor::kTimerNameOptimizerSolveOptimization)
+            .get());
+#endif
     CHECK(problem != NULL);
     ceres::Solver::Options options;
     // TODO configure options
@@ -698,6 +714,13 @@ class ObjectPoseGraphOptimizer {
       std::optional<vslam_types_refactor::OptimizationLogger> &opt_logger,
       std::shared_ptr<std::unordered_map<ceres::ResidualBlockId, double>>
           block_ids_and_residuals_ptr = nullptr) {
+#ifdef RUN_TIMERS
+    CumulativeFunctionTimer::Invocation invoc(
+        vslam_types_refactor::CumulativeTimerFactory::getInstance()
+            .getOrCreateFunctionTimer(
+                vslam_types_refactor::kTimerNameOptimizerSolveOptimization)
+            .get());
+#endif
     CHECK(problem != NULL);
     ceres::Solver::Options options;
     // TODO configure options

--- a/src/refactoring/offline_object_visual_slam_main.cpp
+++ b/src/refactoring/offline_object_visual_slam_main.cpp
@@ -412,10 +412,12 @@ void visualizationStub(
     const double &near_edge_threshold,
     const size_t &pending_obj_min_obs_threshold,
     const std::optional<std::vector<vtr::Pose3D<double>>> &gt_trajectory) {
+#ifdef RUN_TIMERS
   CumulativeFunctionTimer::Invocation invoc(
       vtr::CumulativeTimerFactory::getInstance()
           .getOrCreateFunctionTimer(vtr::kTimerNameVisFunction)
           .get());
+#endif
   bool pgo_opt = false;
   switch (visualization_stage) {
     case vtr::BEFORE_ANY_OPTIMIZATION:
@@ -708,6 +710,12 @@ int main(int argc, char **argv) {
 
   vtr::FullOVSLAMConfig config;
   vtr::readConfiguration(FLAGS_params_config_file, config);
+
+#ifdef RUN_TIMERS
+  // Create an instance so that the factory never goes out of scope
+  vtr::CumulativeTimerFactory &instance =
+      vtr::CumulativeTimerFactory::getInstance();
+#endif
 
   // Hard-coded values -----------------------------------------------------
 
@@ -1130,10 +1138,12 @@ int main(int argc, char **argv) {
                                             const MainPgPtr &pose_graph,
                                             const vtr::FrameId &min_frame_id,
                                             const vtr::FrameId &max_frame_id) {
+#ifdef RUN_TIMERS
         CumulativeFunctionTimer::Invocation invoc(
             vtr::CumulativeTimerFactory::getInstance()
                 .getOrCreateFunctionTimer(vtr::kTimerNameVisualFrontendFunction)
                 .get());
+#endif
         visual_feature_fronted.addVisualFeatureObservations(
             input_problem_data, pose_graph, min_frame_id, max_frame_id);
       };
@@ -1273,6 +1283,12 @@ int main(int argc, char **argv) {
                          std::unordered_map<vtr::CameraId,
                                             std::vector<vtr::RawBoundingBox>>
                              &bounding_boxes_by_cam) {
+#ifdef RUN_TIMERS
+        CumulativeFunctionTimer::Invocation invoc(
+            vtr::CumulativeTimerFactory::getInstance()
+                .getOrCreateFunctionTimer(vtr::kTimerNameBbQuerier)
+                .get());
+#endif
         return bb_querier.retrieveBoundingBoxes(
             frame_id_to_query_for, input_problem_data, bounding_boxes_by_cam);
       };
@@ -1295,6 +1311,12 @@ int main(int argc, char **argv) {
                              const MainPgPtr &pose_graph,
                              const vtr::FrameId &min_frame_id,
                              const vtr::FrameId &frame_to_add) {
+#ifdef RUN_TIMERS
+        CumulativeFunctionTimer::Invocation invoc(
+            vtr::CumulativeTimerFactory::getInstance()
+                .getOrCreateFunctionTimer(vtr::kTimerNameFrameDataAdderTopLevel)
+                .get());
+#endif
         vtr::addFrameDataAssociatedBoundingBox(problem_data,
                                                pose_graph,
                                                min_frame_id,


### PR DESCRIPTION
Add Timer (no segfault)

Testing; No segfault

add timer flag to cmake; add cumulative timer constants

add timer for offline_object_visual_slam_main (remove short timers)

add Timer for object_pose_graph_optimizer (remove small timers)

add Timer for offline_problem_runner (remove small timers)

add Timer for bounding_box_front_end (remove small timers)

untrack timing.json for PR

untrack sequences/20230511183554.json for PR